### PR TITLE
Returning native obj after evaluation done in js-interpreter

### DIFF
--- a/src/ProtectedEvaluator.ts
+++ b/src/ProtectedEvaluator.ts
@@ -46,7 +46,8 @@ const Evaluator: IEvaluator = {
   
     const interpreter = new Interpreter(func, initFunc);
     interpreter.run();
-    return interpreter.getProperty(interpreter.globalObject, 'result');
+    const result = interpreter.getProperty(interpreter.globalObject, 'result');
+    return interpreter.pseudoToNative(result);
   },
 };
 


### PR DESCRIPTION
Couldn't test this at my end after building the project. But I did some overriding in the code and tested this to be working fine. 
The errors in [this ticket](https://trello.com/c/yHeFvG4B/267-uip-267-protectedeval-not-working-with-mergecomponentschema-in-logic) should not come and the object returned from evaluate should be a native object and not one created by js-interpreter.