### PR TITLE
FIO-9942: assign result value from evaluated function

### DIFF
--- a/src/ProtectedEvaluator.ts
+++ b/src/ProtectedEvaluator.ts
@@ -29,7 +29,7 @@ const Evaluator: IEvaluator = {
       return baseEvaluate(func, args, ...rest);
     }
 
-    func = `result = (function() {${func}})()`;
+    func = `result = (function() { value = ${func}; return value; })()`;
     const initFunc = function(interpreter, globalObject) {
       Object.keys(args).forEach((variable) => {
         // Exclude variables which have circular references

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,6 @@ module.exports = {
     }
   },
   externals: {
-    formiojs: 'Formio',
+    '@formio/js': 'Formio',
   },
 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9942

Fixed an issue where the evaluated function string was not correctly assigning a value to the result variable in the interpreter context.
Now value is then properly assigned to the result property on the global object.

## Dependencies
Important to use @formio/js version that uses a version of @formio/core containing the changes:
https://github.com/formio/core/pull/239
https://github.com/formio/core/pull/240

## How has this PR been tested?
manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above