### PR TITLE
Fio 9942 protected eval extends default eval

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@formio/js": "^5.0.1",
+    "@formio/js": "v5.1.0-dev.6208.59bdd3f",
     "@typescript-eslint/eslint-plugin": "^7.10.0",
     "@typescript-eslint/parser": "^7.10.0",
     "eslint": "^9.3.0",
@@ -33,7 +33,7 @@
     "webpack-cli": "^5.1.4"
   },
   "peerDependencies": {
-    "@formio/js": "^5.0.1"
+    "@formio/js": "v5.1.0-dev.6208.59bdd3f"
   },
   "dependencies": {
     "@formio/js-interpreter": "1.1.0-formio.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@formio/js": "v5.1.0-dev.6208.59bdd3f",
+    "@formio/js": "v5.1.0-dev.6214.89da41f",
     "@typescript-eslint/eslint-plugin": "^7.10.0",
     "@typescript-eslint/parser": "^7.10.0",
     "eslint": "^9.3.0",
@@ -33,7 +33,7 @@
     "webpack-cli": "^5.1.4"
   },
   "peerDependencies": {
-    "@formio/js": "v5.1.0-dev.6208.59bdd3f"
+    "@formio/js": "v5.1.0-dev.6214.89da41f"
   },
   "dependencies": {
     "@formio/js-interpreter": "1.1.0-formio.4",

--- a/src/ProtectedEvaluator.ts
+++ b/src/ProtectedEvaluator.ts
@@ -3,6 +3,7 @@ import Interpreter from '@formio/js-interpreter';
 
 const baseEvaluator = (FormioUtils.Evaluator as any).evaluator;
 const baseEvaluate = (FormioUtils.Evaluator as any).evaluate;
+const DefaultEvaluator = (FormioUtils as any).DefaultEvaluator;
 
 export interface IEvaluator {
   noeval?: boolean;
@@ -13,19 +14,21 @@ export interface IEvaluator {
 
 const excludedVariables = ['instance', 'self', 'options'];
 
-const Evaluator: IEvaluator = {
-  noeval: true,
-  protectedEval: true,
-  evaluator: (func: string | any, ...params: any[]): () => any => {
-    if (!Evaluator.protectedEval) {
+export class Evaluator extends DefaultEvaluator {
+  noeval = true;
+  protectedEval = true;
+
+  evaluator(func: string | any, ...params: any[]): () => any {
+    if (!this.protectedEval) {
       return baseEvaluator(func, ...params);
     }
 
     console.warn('No evaluations allowed for safe eval.');
     return () => undefined;
-  },
-  evaluate: (func: string | any, args: any, ...rest: any[]): any => {
-    if (!Evaluator.protectedEval || typeof func !== 'string') {
+  };
+
+  evaluate(func: string | any, args: any, ...rest: any[]): any {
+    if (!this.protectedEval || typeof func !== 'string') {
       return baseEvaluate(func, args, ...rest);
     }
 
@@ -48,7 +51,7 @@ const Evaluator: IEvaluator = {
     interpreter.run();
     const result = interpreter.getProperty(interpreter.globalObject, 'result');
     return interpreter.pseudoToNative(result);
-  },
+  };
 };
 
-export default Evaluator;
+export default new Evaluator();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "preserveConstEnums": true,
     "outDir": "lib",

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,12 +41,12 @@
 
 "@formio/bootstrap@v3.0.0-dev.121.085d187":
   version "3.0.0-dev.121.085d187"
-  resolved "https://pkg.form.io/@formio/bootstrap/-/bootstrap-3.0.0-dev.121.085d187.tgz#7cc8c3a62e531b9b508e68d08fa513241c659da6"
+  resolved "https://registry.yarnpkg.com/@formio/bootstrap/-/bootstrap-3.0.0-dev.121.085d187.tgz#7cc8c3a62e531b9b508e68d08fa513241c659da6"
   integrity sha512-V9AgDNTiFuvw0g/+QbUu2e8c061obSInmwn3qjsxkySg1VtpuVO2hrhgS8Lqxa5Q3IKbgmkrbCJGex8GCxNAnA==
 
 "@formio/core@2.5.1-rc.6":
   version "2.5.1-rc.6"
-  resolved "https://pkg.form.io/@formio/core/-/core-2.5.1-rc.6.tgz#9f7e165fc77051c87266a6c3aa9f29e2d0fe7c2c"
+  resolved "https://registry.yarnpkg.com/@formio/core/-/core-2.5.1-rc.6.tgz#9f7e165fc77051c87266a6c3aa9f29e2d0fe7c2c"
   integrity sha512-oT+mAu5hH8CslJXuZM9FSrQUV+RxD3ZQtgKL7RASGsHsdiz3zf7b4eE5LPs0vK+qaYloGTTMKFNs8vXGGNJQkQ==
   dependencies:
     browser-cookies "^1.2.0"
@@ -68,10 +68,10 @@
   dependencies:
     acorn "^8.12.1"
 
-"@formio/js@v5.1.0-dev.6208.59bdd3f":
-  version "5.1.0-dev.6208.59bdd3f"
-  resolved "https://pkg.form.io/@formio/js/-/js-5.1.0-dev.6208.59bdd3f.tgz#f98b42da213b787544c972622f33ffae62a83f57"
-  integrity sha512-2Yig25hyLJqgGJGrBIf/JyhGWqRUvyxJCiaddWq8/fhbuHuWUlibkxUupE/cJ6dUxqqRw5j7R78m6j3e33f2Sw==
+"@formio/js@v5.1.0-dev.6214.89da41f":
+  version "5.1.0-dev.6214.89da41f"
+  resolved "https://registry.yarnpkg.com/@formio/js/-/js-5.1.0-dev.6214.89da41f.tgz#13b69fded69203fa81579fc0af8686aa187e8cfc"
+  integrity sha512-qe+owbEJ+mSF+763t/t3LPg5qYQwD0plvT0CeepR5RKH3WhwrH5WV/l9QjsgtW2BdwzgUfi9ozwefPCag8Vjeg==
   dependencies:
     "@formio/bootstrap" v3.0.0-dev.121.085d187
     "@formio/core" "2.5.1-rc.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@babel/runtime@^7.9.2":
-  version "7.24.6"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.6.tgz#5b76eb89ad45e2e4a0a8db54c456251469a3358e"
-  integrity sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
   resolved "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -46,35 +39,25 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-9.3.0.tgz#2e8f65c9c55227abc4845b1513c69c32c679d8fe"
   integrity sha512-niBqk8iwv96+yuTwjM6bWg8ovzAPF9qkICsGtcoa5/dmqcEMfdwNAX7+/OHcJHc7wj7XqPxH98oAHytFYlw6Sw==
 
-"@formio/bootstrap@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@formio/bootstrap/-/bootstrap-3.0.1.tgz#57c0fe430441ab69fdcb08c4cbc71fe944c81732"
-  integrity sha512-TAP9Tf/p5l8w8T2NWIA509H9XkzF2OlX6+VRFFz9L2rbVJsYXKUe+DzlkfjIu+8FuqbzlIXpwdydUWiA1qM5vA==
+"@formio/bootstrap@v3.0.0-dev.121.085d187":
+  version "3.0.0-dev.121.085d187"
+  resolved "https://pkg.form.io/@formio/bootstrap/-/bootstrap-3.0.0-dev.121.085d187.tgz#7cc8c3a62e531b9b508e68d08fa513241c659da6"
+  integrity sha512-V9AgDNTiFuvw0g/+QbUu2e8c061obSInmwn3qjsxkySg1VtpuVO2hrhgS8Lqxa5Q3IKbgmkrbCJGex8GCxNAnA==
 
-"@formio/choices.js@^10.2.1":
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/@formio/choices.js/-/choices.js-10.2.1.tgz#d0f5c032d94f33152b6036f6a5bb42fcc4684e31"
-  integrity sha512-NCE5u7jG3XGokJP16MyAbVSUptKu/mpJYAxd4PPIoLiO/l9Do5uoOQ0MgNb9qG9qABJiOX+qNRE8q8RybY/SwQ==
+"@formio/core@2.5.1-rc.6":
+  version "2.5.1-rc.6"
+  resolved "https://pkg.form.io/@formio/core/-/core-2.5.1-rc.6.tgz#9f7e165fc77051c87266a6c3aa9f29e2d0fe7c2c"
+  integrity sha512-oT+mAu5hH8CslJXuZM9FSrQUV+RxD3ZQtgKL7RASGsHsdiz3zf7b4eE5LPs0vK+qaYloGTTMKFNs8vXGGNJQkQ==
   dependencies:
-    deepmerge "^4.2.2"
-    fuse.js "^6.6.2"
-    redux "^4.2.0"
-
-"@formio/core@2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@formio/core/-/core-2.3.2.tgz#16ceffbd6c7120e6ed922b08f50d5d659a4b156c"
-  integrity sha512-tkH9MtDR+nZuTuizy+qlnce03C3hnd4Dm/2eFjY7cEUZdpIIh1QQ9j9s4W47Si/QOMkS7trIVxKUjxuKrt8j6Q==
-  dependencies:
-    "@types/json-logic-js" "^2.0.7"
     browser-cookies "^1.2.0"
-    core-js "^3.37.1"
-    dayjs "^1.11.11"
-    dompurify "^3.1.4"
+    core-js "^3.39.0"
+    dayjs "^1.11.12"
+    dompurify "^3.2.4"
     eventemitter3 "^5.0.0"
     fast-json-patch "^3.1.1"
     fetch-ponyfill "^7.1.0"
-    inputmask "^5.0.9"
-    json-logic-js "^2.0.2"
+    inputmask "5.0.9"
+    json-logic-js "^2.0.5"
     lodash "^4.17.21"
     moment "^2.29.4"
 
@@ -85,26 +68,27 @@
   dependencies:
     acorn "^8.12.1"
 
-"@formio/js@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@formio/js/-/js-5.0.1.tgz#887fab82a62aec2a3322cf5429266d1a6dd26abe"
-  integrity sha512-MVAT9lseEYmdiivVuQRvWxwXpp402YYpStrTkMqi8nvCA/AmFb9Ld5nsFUqQsfzf4jzY5NgefFmoFlSMfTk0Kg==
+"@formio/js@v5.1.0-dev.6208.59bdd3f":
+  version "5.1.0-dev.6208.59bdd3f"
+  resolved "https://pkg.form.io/@formio/js/-/js-5.1.0-dev.6208.59bdd3f.tgz#f98b42da213b787544c972622f33ffae62a83f57"
+  integrity sha512-2Yig25hyLJqgGJGrBIf/JyhGWqRUvyxJCiaddWq8/fhbuHuWUlibkxUupE/cJ6dUxqqRw5j7R78m6j3e33f2Sw==
   dependencies:
-    "@formio/bootstrap" "3.0.1"
-    "@formio/choices.js" "^10.2.1"
-    "@formio/core" "2.3.2"
+    "@formio/bootstrap" v3.0.0-dev.121.085d187
+    "@formio/core" "2.5.1-rc.6"
     "@formio/text-mask-addons" "3.8.0-formio.4"
     "@formio/vanilla-text-mask" "^5.1.1-formio.1"
     abortcontroller-polyfill "^1.7.5"
     autocompleter "^8.0.4"
-    bootstrap "^5.3.3"
+    bootstrap "^5.3.4"
     browser-cookies "^1.2.0"
     browser-md5-file "^1.1.1"
-    compare-versions "^6.0.0-rc.2"
+    choices.js "^11.0.6"
+    compare-versions "^6.1.1"
     core-js "^3.37.1"
+    dayjs "^1.11.13"
     dialog-polyfill "^0.5.6"
     dom-autoscroller "^2.3.4"
-    dompurify "^3.1.3"
+    dompurify "^3.2.5"
     downloadjs "^1.4.7"
     dragula "^3.7.3"
     eventemitter3 "^5.0.1"
@@ -113,12 +97,12 @@
     idb "^7.1.1"
     inputmask "^5.0.8"
     ismobilejs "^1.1.1"
-    json-logic-js "^2.0.2"
+    json-logic-js "^2.0.5"
     jstimezonedetect "^1.0.7"
     jwt-decode "^3.1.2"
     lodash "^4.17.21"
     moment "^2.29.4"
-    moment-timezone "^0.5.44"
+    moment-timezone "^0.5.48"
     quill "^2.0.2"
     signature_pad "^4.2.0"
     string-hash "^1.1.3"
@@ -251,11 +235,6 @@
   version "1.0.5"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
-
-"@types/json-logic-js@^2.0.7":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@types/json-logic-js/-/json-logic-js-2.0.8.tgz#a1108452069a498981813e32dd081754ae6b3395"
-  integrity sha512-WgNsDPuTPKYXl0Jh0IfoCoJoAGGYZt5qzpmjuLSEg7r0cKp/kWtWp0HAsVepyPSPyXiHo6uXp/B/kW/2J1fa2Q==
 
 "@types/json-schema@*", "@types/json-schema@^7.0.8":
   version "7.0.15"
@@ -588,10 +567,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-bootstrap@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.3.tgz#de35e1a765c897ac940021900fcbb831602bac38"
-  integrity sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==
+bootstrap@^5.3.4:
+  version "5.3.7"
+  resolved "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz#8640065036124d961d885d80b5945745e1154d90"
+  integrity sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -660,6 +639,13 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+choices.js@^11.0.6:
+  version "11.1.0"
+  resolved "https://registry.npmjs.org/choices.js/-/choices.js-11.1.0.tgz#4fcfb5834fdf0c7d1959f0261d1bbe526a7c9222"
+  integrity sha512-mIt0uLhedHg2ea/K2PACrVpt391vRGHuOoctPAiHcyemezwzNMxj7jOzNEk8e7EbjLh0S0sspDkSCADOKz9kcw==
+  dependencies:
+    fuse.js "^7.0.0"
+
 chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
@@ -701,10 +687,10 @@ commander@^2.20.0:
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-compare-versions@^6.0.0-rc.2:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz#3f2131e3ae93577df111dba133e6db876ffe127a"
-  integrity sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==
+compare-versions@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -723,6 +709,11 @@ core-js@^3.37.1:
   version "3.41.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.41.0.tgz#57714dafb8c751a6095d028a7428f1fb5834a776"
   integrity sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==
+
+core-js@^3.39.0:
+  version "3.45.0"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-3.45.0.tgz#556c2af44a2d9c73ea7b49504392474a9f7c947e"
+  integrity sha512-c2KZL9lP4DjkN3hk/an4pWn5b5ZefhRJnAc42n6LJ19kSnbeRbdQZE5dSeE2LBol1OwJD3X1BQvFTAsa8ReeDA==
 
 create-point-cb@^1.0.0:
   version "1.2.0"
@@ -752,9 +743,9 @@ custom-event@^1.0.0:
   resolved "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"
   integrity sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==
 
-dayjs@^1.11.11:
+dayjs@^1.11.12, dayjs@^1.11.13:
   version "1.11.13"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
+  resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
   integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
 debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
@@ -768,11 +759,6 @@ deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
-
-deepmerge@^4.2.2:
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
-  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
 dialog-polyfill@^0.5.6:
   version "0.5.6"
@@ -819,10 +805,10 @@ dom-set@^1.0.1:
     is-array "^1.0.1"
     iselement "^1.1.4"
 
-dompurify@^3.1.3, dompurify@^3.1.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.4.tgz#af5a5a11407524431456cf18836c55d13441cd8e"
-  integrity sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==
+dompurify@^3.2.4, dompurify@^3.2.5:
+  version "3.2.6"
+  resolved "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz#ca040a6ad2b88e2a92dc45f38c79f84a714a1cad"
+  integrity sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
@@ -1094,10 +1080,10 @@ function-bind@^1.1.2:
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-fuse.js@^6.6.2:
-  version "6.6.2"
-  resolved "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz#fe463fed4b98c0226ac3da2856a415576dc9a111"
-  integrity sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==
+fuse.js@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz#306228b4befeee11e05b027087c2744158527d09"
+  integrity sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==
 
 glob-parent@^5.1.2:
   version "5.1.2"
@@ -1188,7 +1174,7 @@ imurmurhash@^0.1.4:
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-inputmask@^5.0.8, inputmask@^5.0.9:
+inputmask@5.0.9, inputmask@^5.0.8:
   version "5.0.9"
   resolved "https://registry.yarnpkg.com/inputmask/-/inputmask-5.0.9.tgz#7bf4e83f5e199c88c0edf28545dc23fa208ef4be"
   integrity sha512-s0lUfqcEbel+EQXtehXqwCJGShutgieOaIImFKC/r4reYNvX3foyrChl6LOEvaEgxEbesePIrw1Zi2jhZaDZbQ==
@@ -1280,10 +1266,10 @@ json-buffer@3.0.1:
   resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
-json-logic-js@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.2.tgz#b613e095f5e598cb78f7b9a2bbf638e74cf98158"
-  integrity sha512-ZBtBdMJieqQcH7IX/LaBsr5pX+Y5JIW+EhejtM3Ffg2jdN9Iwf+Ht6TbHnvAZ/YtwyuhPaCBlnvzrwVeWdvGDQ==
+json-logic-js@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.5.tgz#55f0c687dd6f56b02ccdcfdd64171ed998ab5499"
+  integrity sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==
 
 json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
@@ -1418,9 +1404,9 @@ minimatch@^9.0.4:
   dependencies:
     brace-expansion "^2.0.1"
 
-moment-timezone@^0.5.44:
+moment-timezone@^0.5.48:
   version "0.5.48"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.48.tgz#111727bb274734a518ae154b5ca589283f058967"
+  resolved "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz#111727bb274734a518ae154b5ca589283f058967"
   integrity sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==
   dependencies:
     moment "^2.29.4"
@@ -1598,18 +1584,6 @@ rechoir@^0.8.0:
   integrity sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==
   dependencies:
     resolve "^1.20.0"
-
-redux@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
-  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-
-regenerator-runtime@^0.14.0:
-  version "0.14.1"
-  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
-  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9942

## Description

DefaultEvaluator extends DefaultEvaluator (@formio/js).
I prefer to make ProtectedEvaluator class inherit from the DefaultEvaluator (@formio/js) instead Core Evaluator class (@formio/core) because in case of Core Evaluator for correct work ProtectedEvaluator should be expanded with functionality that is already contain in DefaultEvaluator. 

TypeScript compiler target updated from es5 to es6 for compatibility with render 5.x.




## Breaking Changes / Backwards Compatibility
-

## Dependencies
for correct work should use @formio/js with:
https://github.com/formio/formio.js/pull/6214

## How has this PR been tested?
manually

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above