### PR TITLE
FIO-9942: update import of DefaultEvaluator class to keep it out of formUtils

### DIFF
--- a/src/ProtectedEvaluator.ts
+++ b/src/ProtectedEvaluator.ts
@@ -1,9 +1,9 @@
 import {Utils as FormioUtils} from '@formio/js';
 import Interpreter from '@formio/js-interpreter';
+import { DefaultEvaluator } from '@formio/js';
 
-const baseEvaluator = (FormioUtils.Evaluator as any).evaluator;
-const baseEvaluate = (FormioUtils.Evaluator as any).evaluate;
-const DefaultEvaluator = (FormioUtils as any).DefaultEvaluator;
+const baseEvaluator = FormioUtils.Evaluator.evaluator;
+const baseEvaluate = FormioUtils.Evaluator.evaluate;
 
 export interface IEvaluator {
   noeval?: boolean;


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9942

## Description

A small update to an already-merged PR moving the DefaultEvaluator class out of FormioUtils so it is not as confusing.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

[@formio/js#]()

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above